### PR TITLE
Replace Hunger effect applied by Husk and Edibles with Poison or Weakness; Misc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-# Fabric Example Mod
+# No Hunger
+Remove the hunger bar from Minecraft. Additional tweaks to remove the Hunger effect.
 
 ## Setup
 
 For setup instructions please see the [fabric wiki page](https://fabricmc.net/wiki/tutorial:setup) that relates to the IDE that you are using.
-
-## License
-
-This template is available under the CC0 license. Feel free to learn from it and incorporate it in your own projects.

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,12 @@ jar {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			from components.java
+			artifact(remapJar) {
+				builtBy remapJar
+			}
+			artifact(sourcesJar) {
+				builtBy remapSourcesJar
+			}
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ jar {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
+			from components.java
+			
 			artifact(remapJar) {
 				builtBy remapJar
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.0-SNAPSHOT'
+	id 'fabric-loom' version '1.1-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -11,8 +11,13 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-	maven { url "https://maven.shedaniel.me/" }
+	maven { url "https://maven.shedaniel.me/"}
 	maven { url "https://maven.terraformersmc.com/releases/" }
+	// Add repositories to retrieve artifacts from in here.
+	// You should only use this when depending on other mods because
+	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
+	// for more information about repositories.
 }
 
 dependencies {
@@ -24,13 +29,15 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-	// You may need to force-disable transitiveness on them.
 	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_api}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu}"
 
+	// Uncomment the following line to enable the deprecated Fabric API modules. 
+	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
+
+	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
 }
 
 processResources {
@@ -42,8 +49,8 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	it.options.release = 17
 }
 
 java {
@@ -63,13 +70,7 @@ jar {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			// add all the jars that should be included when publishing to maven
-			artifact(remapJar) {
-				builtBy remapJar
-			}
-			artifact(sourcesJar) {
-				builtBy remapSourcesJar
-			}
+			from components.java
 		}
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 	# check these on https://fabricmc.net/develop/
 	minecraft_version=1.19.3
 	yarn_mappings=1.19.3+build.5
-	loader_version=0.14.12
+	loader_version=0.14.14
 
 # Mod Properties
 	mod_version = 1.1.0
@@ -13,6 +13,6 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = nohunger
 
 # Dependencies
-	fabric_version=0.72.0+1.19.3
+	fabric_version=0.74.0+1.19.3
 	cloth_config_api=9.0.94
 	modmenu=5.0.2

--- a/src/main/java/net/Slainlight/NoHunger/NoHungerManager.java
+++ b/src/main/java/net/Slainlight/NoHunger/NoHungerManager.java
@@ -11,57 +11,35 @@ public class NoHungerManager extends HungerManager
 {
     private final PlayerEntity player;
 
-    public NoHungerManager(PlayerEntity player)
-    {
+    public NoHungerManager(PlayerEntity player) {
         this.player = player;
     }
 
-    public void add(int health) {
+    public void NoHungerAdd(int health) {
         player.heal(health);
     }
 
     @Override
     public void add(int hunger, float saturation) {
-        add(hunger);
+        NoHungerAdd(hunger);
     }
 
     @Override
     public void eat(Item item, ItemStack itemStack) {
         if (item.isFood()) {
             FoodComponent foodComponent = item.getFoodComponent();
-            add(foodComponent.getHunger());
+            NoHungerAdd(foodComponent.getHunger());
         }
     }
 
     @Override
-    public void update(PlayerEntity player) {
-
+    public boolean isNotFull() {
+        return player.getHealth() < player.getMaxHealth();
     }
 
     @Override
-    public void readNbt(NbtCompound nbt)
-    {
-
-    }
-
-    @Override
-    public void writeNbt(NbtCompound nbt)
-    {
-
-    }
-
-    @Override
-    public int getFoodLevel()
-    {
-        return 10;
-    }
-
-    @Override
-    public boolean isNotFull() { return player.getHealth() < player.getMaxHealth(); }
-
-    @Override
-    public void addExhaustion(float exhaustion) {
-        // NO-OP
+    public int getFoodLevel() {
+        return 20;
     }
 
     @Override
@@ -70,13 +48,37 @@ public class NoHungerManager extends HungerManager
     }
 
     @Override
+    public void update(PlayerEntity player) {
+        // NO-OP
+    }
+
+    @Override
+    public void readNbt(NbtCompound nbt) {
+        // NO-OP
+    }
+
+    @Override
+    public void writeNbt(NbtCompound nbt) {
+        // NO-OP
+    }
+
+    @Override
+    public void addExhaustion(float exhaustion) {
+        // NO-OP
+    }
+
+    @Override
     public void setFoodLevel(int foodLevel) {
         // NO-OP
     }
 
     @Override
-    public void setSaturationLevel(float saturationLevel)
-    {
+    public void setExhaustion(float exhaustion) {
+        // NO-OP
+    }
 
+    @Override
+    public void setSaturationLevel(float saturationLevel) {
+        // NO-OP
     }
 }

--- a/src/main/java/net/Slainlight/NoHunger/mixin/MixinFoodComponents.java
+++ b/src/main/java/net/Slainlight/NoHunger/mixin/MixinFoodComponents.java
@@ -1,5 +1,6 @@
 package net.Slainlight.NoHunger.mixin;
 
+import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.item.FoodComponents;
 import org.objectweb.asm.Opcodes;
@@ -15,12 +16,43 @@ public class MixinFoodComponents {
             method = "<clinit>",
             slice = @Slice(
                     from = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;RABBIT_STEW:Lnet/minecraft/item/FoodComponent;"),
-                    to = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;ROTTEN_FLESH:Lnet/minecraft/item/FoodComponent;")),
+                    to = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;ROTTEN_FLESH:Lnet/minecraft/item/FoodComponent;")
+            ),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/StatusEffectInstance;<init>(Lnet/minecraft/entity/effect/StatusEffect;II)V"),
             allow = 1
     )
-    private static void NoHunger$rottenFleshCausesHunger(Args args) {
+    private static void NoHunger$rottenFleshCausesPoison(Args args) {
         args.set(0, StatusEffects.POISON);
         args.set(1, 150);
+    }
+
+    @ModifyArgs(
+            method = "<clinit>",
+            slice = @Slice(
+                    from = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;POTATO:Lnet/minecraft/item/FoodComponent;"),
+                    to = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;PUFFERFISH:Lnet/minecraft/item/FoodComponent;")
+            ),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/StatusEffectInstance;<init>(Lnet/minecraft/entity/effect/StatusEffect;II)V"),
+            allow = 3
+    )
+    private static void NoHunger$pufferfishCausesWeakness(Args args) {
+        StatusEffect StatusArg = args.get(0);
+        if (StatusArg == StatusEffects.HUNGER) {
+            args.set(0, StatusEffects.WEAKNESS);
+            args.set(1, 150);
+        }
+    }
+
+    @ModifyArgs(
+            method = "<clinit>",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/StatusEffectInstance;<init>(Lnet/minecraft/entity/effect/StatusEffect;II)V"),
+            allow = 1
+    )
+    private static void NoHunger$rawChickenCausesPoison(Args args) {
+        StatusEffect StatusArg = args.get(0);
+        if (StatusArg == StatusEffects.HUNGER) {
+            args.set(0, StatusEffects.POISON);
+            args.set(1, 150);
+        }
     }
 }

--- a/src/main/java/net/Slainlight/NoHunger/mixin/MixinFoodComponents.java
+++ b/src/main/java/net/Slainlight/NoHunger/mixin/MixinFoodComponents.java
@@ -1,0 +1,26 @@
+package net.Slainlight.NoHunger.mixin;
+
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.item.FoodComponents;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(FoodComponents.class)
+public class MixinFoodComponents {
+    @ModifyArgs(
+            method = "<clinit>",
+            slice = @Slice(
+                    from = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;RABBIT_STEW:Lnet/minecraft/item/FoodComponent;"),
+                    to = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;ROTTEN_FLESH:Lnet/minecraft/item/FoodComponent;")),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/StatusEffectInstance;<init>(Lnet/minecraft/entity/effect/StatusEffect;II)V"),
+            allow = 1
+    )
+    private static void NoHunger$rottenFleshCausesHunger(Args args) {
+        args.set(0, StatusEffects.POISON);
+        args.set(1, 150);
+    }
+}

--- a/src/main/java/net/Slainlight/NoHunger/mixin/MixinFoodComponents.java
+++ b/src/main/java/net/Slainlight/NoHunger/mixin/MixinFoodComponents.java
@@ -45,6 +45,10 @@ public class MixinFoodComponents {
 
     @ModifyArgs(
             method = "<clinit>",
+            slice = @Slice(
+                    from = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;CARROT:Lnet/minecraft/item/FoodComponent;"),
+                    to = @At(value = "FIELD", opcode = Opcodes.PUTSTATIC, target = "Lnet/minecraft/item/FoodComponents;CHICKEN:Lnet/minecraft/item/FoodComponent;")
+            ),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/StatusEffectInstance;<init>(Lnet/minecraft/entity/effect/StatusEffect;II)V"),
             allow = 1
     )

--- a/src/main/java/net/Slainlight/NoHunger/mixin/MixinHusk.java
+++ b/src/main/java/net/Slainlight/NoHunger/mixin/MixinHusk.java
@@ -1,0 +1,39 @@
+package net.Slainlight.NoHunger.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.entity.mob.HuskEntity;
+import net.minecraft.entity.mob.ZombieEntity;
+import net.minecraft.world.World;
+
+@Mixin(HuskEntity.class)
+public class MixinHusk 
+extends ZombieEntity {
+    public MixinHusk(EntityType<? extends ZombieEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @ModifyArg(method = "Lnet/minecraft/entity/mob/HuskEntity;tryAttack", 
+               at = @At(value = "INVOKE", 
+               target = "Lnet/minecraft/entity/LivingEntity;addStatusEffect()Z"), index = 0)
+    StatusEffectInstance injected(StatusEffectInstance orig) {
+        float f = this.world.getLocalDifficulty(this.getBlockPos()).getLocalDifficulty();
+        StatusEffectInstance inj = new StatusEffectInstance(StatusEffects.WEAKNESS, 90 * (int)f);
+        return inj;
+    }
+
+    // @Overwrite
+    // public boolean tryAttack(Entity target) {
+    //     boolean bl = super.tryAttack(target);
+    //     if (bl && this.getMainHandStack().isEmpty() && target instanceof LivingEntity) {
+    //         float f = this.world.getLocalDifficulty(this.getBlockPos()).getLocalDifficulty();
+    //         ((LivingEntity)target).addStatusEffect(new StatusEffectInstance(StatusEffects.WEAKNESS, 90 * (int)f), this);
+    //     }
+    //     return bl;
+    // }
+}

--- a/src/main/java/net/Slainlight/NoHunger/mixin/MixinHusk.java
+++ b/src/main/java/net/Slainlight/NoHunger/mixin/MixinHusk.java
@@ -21,7 +21,7 @@ extends ZombieEntity {
     @ModifyArg(method = "tryAttack",
                at = @At(value = "INVOKE", 
                target = "Lnet/minecraft/entity/LivingEntity;addStatusEffect(Lnet/minecraft/entity/effect/StatusEffectInstance;Lnet/minecraft/entity/Entity;)Z"), index = 0)
-    StatusEffectInstance injected(StatusEffectInstance orig) {
+    StatusEffectInstance NoHunger$husksGiveWeakness(StatusEffectInstance orig) {
         float f = this.world.getLocalDifficulty(this.getBlockPos()).getLocalDifficulty();
         return new StatusEffectInstance(StatusEffects.WEAKNESS, 90 * (int)f);
     }

--- a/src/main/java/net/Slainlight/NoHunger/mixin/MixinHusk.java
+++ b/src/main/java/net/Slainlight/NoHunger/mixin/MixinHusk.java
@@ -18,22 +18,11 @@ extends ZombieEntity {
         super(entityType, world);
     }
 
-    @ModifyArg(method = "Lnet/minecraft/entity/mob/HuskEntity;tryAttack", 
+    @ModifyArg(method = "tryAttack",
                at = @At(value = "INVOKE", 
-               target = "Lnet/minecraft/entity/LivingEntity;addStatusEffect()Z"), index = 0)
+               target = "Lnet/minecraft/entity/LivingEntity;addStatusEffect(Lnet/minecraft/entity/effect/StatusEffectInstance;Lnet/minecraft/entity/Entity;)Z"), index = 0)
     StatusEffectInstance injected(StatusEffectInstance orig) {
         float f = this.world.getLocalDifficulty(this.getBlockPos()).getLocalDifficulty();
-        StatusEffectInstance inj = new StatusEffectInstance(StatusEffects.WEAKNESS, 90 * (int)f);
-        return inj;
+        return new StatusEffectInstance(StatusEffects.WEAKNESS, 90 * (int)f);
     }
-
-    // @Overwrite
-    // public boolean tryAttack(Entity target) {
-    //     boolean bl = super.tryAttack(target);
-    //     if (bl && this.getMainHandStack().isEmpty() && target instanceof LivingEntity) {
-    //         float f = this.world.getLocalDifficulty(this.getBlockPos()).getLocalDifficulty();
-    //         ((LivingEntity)target).addStatusEffect(new StatusEffectInstance(StatusEffects.WEAKNESS, 90 * (int)f), this);
-    //     }
-    //     return bl;
-    // }
 }

--- a/src/main/resources/nohunger.mixins.json
+++ b/src/main/resources/nohunger.mixins.json
@@ -7,7 +7,8 @@
     "MixinPlayerEntity",
     "MixinItem",
     "MixinItemSettings",
-    "MixinHusk"
+    "MixinHusk",
+    "MixinFoodComponents"
   ],
   "client": [
     "MixinInGameHud"

--- a/src/main/resources/nohunger.mixins.json
+++ b/src/main/resources/nohunger.mixins.json
@@ -2,11 +2,12 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.Slainlight.NoHunger.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "MixinPlayerEntity",
     "MixinItem",
-    "MixinItemSettings"
+    "MixinItemSettings",
+    "MixinHusk"
   ],
   "client": [
     "MixinInGameHud"


### PR DESCRIPTION
This fork bumps the version of fabric used in the build, alters the Readme to be different from the template and replaces the Hunger effects applied by Husks and different food items with either Poison or Weakness.